### PR TITLE
Model-100: Add a missing separator to the core dir paths

### DIFF
--- a/Model-100/firmware-builder/build-all
+++ b/Model-100/firmware-builder/build-all
@@ -171,9 +171,9 @@ sub build_gd32_firmware {
     set_cwd( repo_dir('kaleidoscope') );
     make("setup");
     describe_repo_from_cwd('kaleidoscope');
-    set_cwd( repo_dir('kaleidoscope') .".arduino/user/hardware/keyboardio/avr");
+    set_cwd( repo_dir('kaleidoscope') ."/.arduino/user/hardware/keyboardio/avr");
     describe_repo_from_cwd('kaleidoscope-core-avr');
-    set_cwd( repo_dir('kaleidoscope') .".arduino/user/hardware/keyboardio/gd32");
+    set_cwd( repo_dir('kaleidoscope') ."/.arduino/user/hardware/keyboardio/gd32");
     describe_repo_from_cwd('kaleidoscope-core-gd32');
 
     my $version_information = '\"kaleidoscope=' . $git_tags{'kaleidoscope'} . '\"';


### PR DESCRIPTION
Without the separator, the script tried to cd to a non-existent directory, and ended up returning the repo description for the then-current directory, Kaleidoscope.
